### PR TITLE
Rectify npm build cmd for server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },


### PR DESCRIPTION
## Changes in this PR

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [x] Refactor/Performance enhancements

## Overview

- Original cmd `ng build` allocates insufficient memory for server (1GB ram)
- Update command to allow JS to allocate more heap space (8GB) for build script
